### PR TITLE
fix(premerge-checks): change condition for job to run

### DIFF
--- a/.github/workflows/pre-merge-checks-apigw.yml
+++ b/.github/workflows/pre-merge-checks-apigw.yml
@@ -28,7 +28,7 @@ jobs:
 
   pre-merge-checks:
     # Run only when PR is assigned, even on subsequent commits (i.e. synchronize)
-    if: github.event.pull_request.assignee != null
+    if: (github.event_name == 'pull_request' && github.event.pull_request.assignee != null) || github.event_name == 'workflow_dispatch'
 
     runs-on: ubuntu-latest
     timeout-minutes: 40

--- a/.github/workflows/pre-merge-checks-app.yml
+++ b/.github/workflows/pre-merge-checks-app.yml
@@ -28,7 +28,7 @@ jobs:
 
   pre-merge-checks:
     # Run only when PR is assigned, even on subsequent commits (i.e. synchronize)
-    if: github.event.pull_request.assignee != null
+    if: (github.event_name == 'pull_request' && github.event.pull_request.assignee != null) || github.event_name == 'workflow_dispatch'
 
     runs-on: ubuntu-latest
     timeout-minutes: 40

--- a/.github/workflows/pre-merge-checks-core-mods.yml
+++ b/.github/workflows/pre-merge-checks-core-mods.yml
@@ -28,7 +28,7 @@ jobs:
 
   pre-merge-checks:
     # Run only when PR is assigned, even on subsequent commits (i.e. synchronize)
-    if: github.event.pull_request.assignee != null
+    if: (github.event_name == 'pull_request' && github.event.pull_request.assignee != null) || github.event_name == 'workflow_dispatch'
 
     runs-on: ubuntu-latest
     timeout-minutes: 40

--- a/.github/workflows/pre-merge-checks-core.yml
+++ b/.github/workflows/pre-merge-checks-core.yml
@@ -28,7 +28,7 @@ jobs:
 
   pre-merge-checks:
     # Run only when PR is assigned, even on subsequent commits (i.e. synchronize)
-    if: github.event.pull_request.assignee != null
+    if: (github.event_name == 'pull_request' && github.event.pull_request.assignee != null) || github.event_name == 'workflow_dispatch'
 
     runs-on: ubuntu-latest
     timeout-minutes: 40

--- a/.github/workflows/pre-merge-checks-plugin-ale.yml
+++ b/.github/workflows/pre-merge-checks-plugin-ale.yml
@@ -30,7 +30,7 @@ jobs:
 
   pre-merge-checks:
     # Run only when PR is assigned, even on subsequent commits (i.e. synchronize)
-    if: github.event.pull_request.assignee != null
+    if: (github.event_name == 'pull_request' && github.event.pull_request.assignee != null) || github.event_name == 'workflow_dispatch'
 
     runs-on: ubuntu-latest
     timeout-minutes: 40

--- a/.github/workflows/pre-merge-checks-plugin-fmtc.yml
+++ b/.github/workflows/pre-merge-checks-plugin-fmtc.yml
@@ -28,7 +28,7 @@ jobs:
 
   pre-merge-checks:
     # Run only when PR is assigned, even on subsequent commits (i.e. synchronize)
-    if: github.event.pull_request.assignee != null
+    if: (github.event_name == 'pull_request' && github.event.pull_request.assignee != null) || github.event_name == 'workflow_dispatch'
 
     runs-on: ubuntu-latest
     timeout-minutes: 40

--- a/.github/workflows/pre-merge-checks-plugin-fmtr.yml
+++ b/.github/workflows/pre-merge-checks-plugin-fmtr.yml
@@ -28,7 +28,7 @@ jobs:
 
   pre-merge-checks:
     # Run only when PR is assigned, even on subsequent commits (i.e. synchronize)
-    if: github.event.pull_request.assignee != null
+    if: (github.event_name == 'pull_request' && github.event.pull_request.assignee != null) || github.event_name == 'workflow_dispatch'
 
     runs-on: ubuntu-latest
     timeout-minutes: 40

--- a/.github/workflows/pre-merge-checks-plugin-ict.yml
+++ b/.github/workflows/pre-merge-checks-plugin-ict.yml
@@ -28,7 +28,7 @@ jobs:
 
   pre-merge-checks:
     # Run only when PR is assigned, even on subsequent commits (i.e. synchronize)
-    if: github.event.pull_request.assignee != null
+    if: (github.event_name == 'pull_request' && github.event.pull_request.assignee != null) || github.event_name == 'workflow_dispatch'
 
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/pre-merge-checks-plugin-pdp.yml
+++ b/.github/workflows/pre-merge-checks-plugin-pdp.yml
@@ -28,7 +28,7 @@ jobs:
 
   pre-merge-checks:
     # Run only when PR is assigned, even on subsequent commits (i.e. synchronize)
-    if: github.event.pull_request.assignee != null
+    if: (github.event_name == 'pull_request' && github.event.pull_request.assignee != null) || github.event_name == 'workflow_dispatch'
 
     runs-on: ubuntu-latest
     timeout-minutes: 40

--- a/.github/workflows/pre-merge-checks-plugin-rt.yml
+++ b/.github/workflows/pre-merge-checks-plugin-rt.yml
@@ -28,7 +28,7 @@ jobs:
 
   pre-merge-checks:
     # Run only when PR is assigned, even on subsequent commits (i.e. synchronize)
-    if: github.event.pull_request.assignee != null
+    if: (github.event_name == 'pull_request' && github.event.pull_request.assignee != null) || github.event_name == 'workflow_dispatch'
 
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/pre-merge-checks-plugin-st.yml
+++ b/.github/workflows/pre-merge-checks-plugin-st.yml
@@ -28,7 +28,7 @@ jobs:
 
   pre-merge-checks:
     # Run only when PR is assigned, even on subsequent commits (i.e. synchronize)
-    if: github.event.pull_request.assignee != null
+    if: (github.event_name == 'pull_request' && github.event.pull_request.assignee != null) || github.event_name == 'workflow_dispatch'
 
     runs-on: ubuntu-latest
     timeout-minutes: 40

--- a/.github/workflows/pre-merge-checks-portal.yml
+++ b/.github/workflows/pre-merge-checks-portal.yml
@@ -28,7 +28,7 @@ jobs:
 
   pre-merge-checks:
     # Run only when PR is assigned, even on subsequent commits (i.e. synchronize)
-    if: github.event.pull_request.assignee != null
+    if: (github.event_name == 'pull_request' && github.event.pull_request.assignee != null) || github.event_name == 'workflow_dispatch'
 
     runs-on: ubuntu-latest
     timeout-minutes: 40


### PR DESCRIPTION
## Description

[Provide a brief description of the changes or features introduced by this pull request.]

Change condition for job to run to include 'workflow_dispatch' event to allow for manual triggering of the GHA.

## Motivation and Context

Allow pre-merge check to be triggered manually to facilitate review work.

## Type of Change

- ci: Changes to the CI/CD configuration or scripts

## How to Test

Existing unit tests

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [ ]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]