### PR TITLE
included flake8 file to allow more characters

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+extend-ignore = E203


### PR DESCRIPTION
## Description

Pre-merge checks are done before we can merge our codes into main. However, one of the pre-merge checks (flake8) has a word limit of 79 for each line by default.

## Motivation and Context

We think that limiting the no. of characters to 79 for each line maybe affect the readability. We have increased the number of characters to 120 by adding our own flake8 configuration file as that was what we have been using for development

## Type of Change

<!-- Select the appropriate type of change: -->
<!-- - fix: A bug fix -->

## How to Test

Change directory to any of the algorithms and run the flake8 test script

- `cd stock-plugins/aiverify.stock.fairness-metrics-toolbox-for-classification/algorithms/fairness_metrics_toolbox_for_classification`
- `chmod +x ci/run-flake8.sh`
-  `bash ci/run-flake8.sh`

[Provide clear instructions on how to test and verify the changes introduced by this pull request, including any specific unit tests you have created to demonstrate your changes.]

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [ ]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.

## Screenshots (if applicable)

-

## Additional Notes

-