### PR TITLE
Modified code to process message in a seperate process initially inst…

### DIFF
--- a/test-engine-app/test_engine_app/enums/process_status.py
+++ b/test-engine-app/test_engine_app/enums/process_status.py
@@ -1,0 +1,10 @@
+from enum import Enum, auto
+
+
+class ProcessStatus(Enum):
+    """
+    The ProcessStatus enum class specifies the different process status
+    """
+
+    UPDATE = auto()
+    COMPLETE = auto()

--- a/test-engine-app/test_engine_app/processing/task_processing.py
+++ b/test-engine-app/test_engine_app/processing/task_processing.py
@@ -1,10 +1,16 @@
 import copy
 import logging
-import queue
-from multiprocessing import Lock
-from typing import Callable, Dict, Tuple, Union
+from typing import Dict, Tuple, Union
 
 import pathos
+from test_engine_app.app_logger import AppLogger
+from test_engine_app.enums.process_status import ProcessStatus
+from test_engine_app.enums.task_status import TaskStatus
+from test_engine_app.enums.task_type import TaskType
+from test_engine_app.processing.plugin_controller import PluginController
+from test_engine_app.processing.stream_processing import StreamProcessing
+from test_engine_app.processing.task_argument import TaskArgument
+from test_engine_app.processing.task_result import TaskResult
 from test_engine_core.interfaces.ialgorithm import IAlgorithm
 from test_engine_core.interfaces.idata import IData
 from test_engine_core.interfaces.imodel import IModel
@@ -14,98 +20,82 @@ from test_engine_core.plugins.enums.data_plugin_type import DataPluginType
 from test_engine_core.utils.json_utils import remove_numpy_formats, validate_json
 from test_engine_core.utils.validate_checks import is_empty_string
 
-from test_engine_app.app_logger import AppLogger
-from test_engine_app.enums.task_status import TaskStatus
-from test_engine_app.processing.stream_processing import StreamProcessing
-from test_engine_app.processing.task_argument import TaskArgument
-from test_engine_app.processing.task_result import TaskResult
-
 
 class TaskProcessing:
-    """
-    TaskProcessing class focuses on how to process pending and new tasks.
-    """
-
-    lock: Lock = Lock()
-
-    def __init__(
-        self, logger: AppLogger, task_update_cb: Callable, task_result: TaskResult
-    ):
-        self._logger: AppLogger = logger
-        self._algorithm_process: Union[pathos.helpers.mp.Process, None] = None
-        self._to_stop: bool = False
-        self._task_update_callback: Callable = task_update_cb
-        self._task_result: TaskResult = task_result
-
-    def _get_algorithm_process(self) -> Union[pathos.helpers.mp.Process, None]:
-        """
-        A helper method to return the running algorithm process
-
-        Returns:
-            Union[pathos.helpers.mp.Process, None]: An algorithm process or None
-        """
-        with TaskProcessing.lock:
-            return self._algorithm_process
-
-    def _set_algorithm_process(
-        self, algorithm_process: Union[pathos.helpers.mp.Process, None]
-    ) -> None:
-        """
-        A helper method to set the algorithm process
-
-        Args:
-            algorithm_process (Union[pathos.helpers.mp.Process, None]): Algorithm process or None
-        """
-        with TaskProcessing.lock:
-            self._algorithm_process = algorithm_process
+    _to_stop: bool = False
+    _logger: Union[AppLogger, None] = None
+    _message_id: str = ""
+    _message_arguments: str = ""
+    _result_queue: Union[pathos.helpers.mp.Queue, None] = None
+    _task_argument: Union[TaskArgument, None] = None
+    _task_result: Union[TaskResult, None] = None
+    _task_type: Union[TaskType, None] = None
 
     @staticmethod
-    def run_algorithm_in_process(
-        algorithm_instance: IAlgorithm, results: pathos.helpers.mp.Queue
+    def run_task_processing_in_process(
+        logger: AppLogger,
+        task_argument: TaskArgument,
+        message_id: str,
+        message_arguments: str,
+        task_type: TaskType,
+        result_queue: pathos.helpers.mp.Queue,
     ) -> None:
         """
-        A method that runs in a process to generate the results from the specific algorithm.
-        The results will be placed in the queue and returned.
+        A method that runs in a process to generate the results from the task argument
+        The updates and results will be placed in the queue and returned.
 
         Args:
-            algorithm_instance (IAlgorithm): The algorithm instance
-            results (pathos.helpers.mp.Queue): The multiprocessing queue to store results and return to the caller
+            logger (AppLogger): The reference logger
+            task_argument (TaskArgument): The task arguments
+            message_id (str): The redis message id
+            message_arguments (str): The redis message arguments
+            task_type (TaskType): The task type
+            result_queue (pathos.helpers.mp.Queue): The multiprocessing queue to store results and return to the caller
         """
-        try:
-            # Generate the results using plugin and set task results
-            # Put the results in the queue
-            algorithm_instance.generate()
-            results.put((True, algorithm_instance.get_results()))
+        # Store the values
+        TaskProcessing._logger = logger
+        TaskProcessing._task_argument = task_argument
+        TaskProcessing._message_id = message_id
+        TaskProcessing._message_arguments = message_arguments
+        TaskProcessing._task_type = task_type
+        TaskProcessing._task_result = TaskResult(TaskProcessing._logger)
+        TaskProcessing._result_queue = result_queue
+        TaskProcessing._to_stop = False
 
-        except Exception as exception:
-            # Catch all error and Update the exception message in the queue
-            results.put((False, str(exception)))
+        PluginController.set_logger(TaskProcessing._logger)
+        AppLogger.add_to_log(
+            TaskProcessing._logger,
+            logging.INFO,
+            f"The task validation is successful: {TaskProcessing._task_argument.id}",
+        )
+        AppLogger.add_to_log(
+            TaskProcessing._logger,
+            logging.INFO,
+            f"Working on task: "
+            f"message_id {TaskProcessing._message_id}, "
+            f"message_args {TaskProcessing._message_arguments}, "
+            f"task_type: {TaskProcessing._task_type}",
+        )
 
-    def stop(self) -> None:
-        """
-        A method to stop all processing
-        """
-        AppLogger.add_to_log(self._logger, logging.INFO, "Stopping task processing")
-        self._to_stop = True
-
-        # Check and terminate the process if running
-        running_process = self._get_algorithm_process()
-        if running_process:
-            # Process is running. Terminate it
-            running_process.terminate()
+        # Process the incoming task
+        if TaskProcessing._task_type is TaskType.PENDING:
+            is_success, error_messages = TaskProcessing.process_pending_task()
         else:
-            # Unable to terminate
-            AppLogger.add_to_log(
-                self._logger, logging.INFO, "There are no running task"
-            )
+            is_success, error_messages = TaskProcessing.process_new_task()
 
-    def process_new_task(self, task_argument: TaskArgument) -> Tuple[bool, str]:
+        # Attach the result in the result queue
+        TaskProcessing._result_queue.put(
+            (
+                ProcessStatus.COMPLETE,
+                (is_success, TaskProcessing._task_result, error_messages),
+            )
+        )
+
+    @staticmethod
+    def process_new_task() -> Tuple[bool, str]:
         """
         A method to process on new tasks
         It will run the task and set the respective task response
-
-        Args:
-            task_argument (TaskArgument): Contains the arguments for this task
 
         Returns:
             Tuple[bool, str]: Returns bool on whether it is successful and indicate the error messages if failure
@@ -116,9 +106,13 @@ class TaskProcessing:
 
         try:
             # Set current task as Running and send update
-            self._task_result.set_status(TaskStatus.RUNNING)
-            AppLogger.add_to_log(self._logger, logging.INFO, "Sending task update")
-            self._task_update_callback()
+            TaskProcessing._task_result.set_status(TaskStatus.RUNNING)
+            AppLogger.add_to_log(
+                TaskProcessing._logger, logging.INFO, "Sending task update"
+            )
+            TaskProcessing._result_queue.put(
+                (ProcessStatus.UPDATE, TaskProcessing._task_result)
+            )
 
             # Load instances
             (
@@ -128,7 +122,7 @@ class TaskProcessing:
                 _,
                 algorithm_serializer_instance,
                 load_error_messages,
-            ) = self._load_instances(task_argument)
+            ) = TaskProcessing._load_instances(TaskProcessing._task_argument)
             if not (
                 is_load_success
                 and data_serializer_instance[0]
@@ -141,65 +135,42 @@ class TaskProcessing:
                 model_instance = model_serializer_instance[0]
                 algorithm_instance = algorithm_serializer_instance[0]
 
-            # Run the algorithm instance in a Process and will return results when completed.
-            # If there is a process termination required, will terminate the process.
-            # Create a new queue for the process to place the results
-            with pathos.helpers.mp.Manager() as manager:
-                results_queue = manager.Queue()
+            # Generate and get the output from the algorithm process
+            algorithm_instance.generate()
 
-                # Create the Process
-                new_process = pathos.helpers.mp.Process(
-                    target=TaskProcessing.run_algorithm_in_process,
-                    args=(algorithm_instance, results_queue),
-                )
+            process_output = algorithm_instance.get_results()
+            if not process_output:
+                # Exception while processing algorithm
+                raise RuntimeError(process_output)
 
-                # Set the process before starting
-                self._set_algorithm_process(new_process)
-                new_process.start()
-                new_process.join()
+            # Get the task results and convert to json friendly and validate against the output schema
+            AppLogger.add_to_log(
+                TaskProcessing._logger,
+                logging.INFO,
+                f"The raw task results: {process_output}",
+            )
+            task_results = remove_numpy_formats(process_output)
+            (
+                is_validation_success,
+                validation_error_messages,
+            ) = TaskProcessing._validate_task_results(
+                task_results,
+                TaskProcessing._task_argument.algorithm_plugin_information.get_algorithm_output_schema(),
+            )
 
-                # Retrieve the result from the queue
-                try:
-                    results = results_queue.get(timeout=1)
-                except queue.Empty:
-                    if self._to_stop:
-                        raise RuntimeError("The user cancelled the task")
-                    else:
-                        raise RuntimeError("The algorithm has generated no results")
-
-                # Get the output from the algorithm process
-                is_processing_success, process_output = results
-                if not is_processing_success:
-                    # Exception while processing algorithm
-                    raise RuntimeError(process_output)
-
-                # Get the task results and convert to json friendly and validate against the output schema
+            if is_validation_success:
+                TaskProcessing._task_result.set_results(task_results)
+                is_success = True
+                error_messages = ""
+            else:
+                # Validation failed
                 AppLogger.add_to_log(
-                    self._logger,
-                    logging.INFO,
-                    f"The raw task results: {process_output}",
+                    TaskProcessing._logger,
+                    logging.ERROR,
+                    f"Failed output schema validation: "
+                    f"Task Results: {task_results}",
                 )
-                task_results = remove_numpy_formats(process_output)
-                (
-                    is_validation_success,
-                    validation_error_messages,
-                ) = self._validate_task_results(
-                    task_results,
-                    task_argument.algorithm_plugin_information.get_algorithm_output_schema(),
-                )
-                if is_validation_success:
-                    self._task_result.set_results(task_results)
-                    is_success = True
-                    error_messages = ""
-                else:
-                    # Validation failed
-                    AppLogger.add_to_log(
-                        self._logger,
-                        logging.ERROR,
-                        f"Failed output schema validation: "
-                        f"Task Results: {task_results}",
-                    )
-                    raise RuntimeError(validation_error_messages)
+                raise RuntimeError(validation_error_messages)
 
         except Exception as exception:
             is_success = False
@@ -208,7 +179,7 @@ class TaskProcessing:
         finally:
             if is_success:
                 # Set current task as success
-                self._task_result.set_success()
+                TaskProcessing._task_result.set_success()
 
             else:
                 if is_empty_string(error_messages):
@@ -216,12 +187,12 @@ class TaskProcessing:
 
                 # Set the error and logs messages
                 AppLogger.add_to_log(
-                    self._logger,
+                    TaskProcessing._logger,
                     logging.WARNING,
                     f"The task terminated: {error_messages}",
                 )
                 AppLogger.add_error_to_log(
-                    self._logger,
+                    TaskProcessing._logger,
                     "SYS",
                     "CSYSx00146",
                     f"Task Terminated: {error_messages}",
@@ -229,11 +200,8 @@ class TaskProcessing:
                     "task_processing.py",
                 )
 
-                # Set current task as failure / cancelled
-                if self._to_stop:
-                    self._task_result.set_cancelled()
-                else:
-                    self._task_result.set_failure()
+                # Set current task as failed
+                TaskProcessing._task_result.set_failure()
 
             # Perform clean up for model instance
             if model_instance:
@@ -241,36 +209,36 @@ class TaskProcessing:
 
         return is_success, error_messages
 
-    def process_pending_task(self, task_arguments: TaskArgument) -> Tuple[bool, str]:
+    @staticmethod
+    def process_pending_task() -> Tuple[bool, str]:
         """
         A method to process on pending tasks
         It will write error logs and set the respective task response to set in hset
-
-        Args:
-            task_arguments (TaskArgument): Contains the pending task arguments
 
         Returns:
             Tuple[bool, str]: Returns True and no error messages
         """
         # Set the error and logs messages
         AppLogger.add_to_log(
-            self._logger, logging.INFO, f"The task terminated: {task_arguments.id}"
+            TaskProcessing._logger,
+            logging.INFO,
+            f"The task terminated: {TaskProcessing._task_argument.id}",
         )
         AppLogger.add_error_to_log(
-            self._logger,
+            TaskProcessing._logger,
             "SYS",
             "CSYSx00146",
-            f"Task Terminated: {task_arguments.id}",
+            f"Task Terminated: {TaskProcessing._task_argument.id}",
             "Warning",
             "task_processing.py",
         )
-
         # Set current task as failure
-        self._task_result.set_failure()
+        TaskProcessing._task_result.set_failure()
         return True, ""
 
+    @staticmethod
     def _load_instances(
-        self, task_argument: TaskArgument
+        task_argument: TaskArgument,
     ) -> Tuple[
         bool,
         Tuple[Union[IData, None], Union[ISerializer, None]],
@@ -295,24 +263,27 @@ class TaskProcessing:
             If it is not successful, it will return the error messages.
         """
         # Identify if the model is a pipeline
-        if StreamProcessing.detect_pipeline(self._logger, task_argument.model):
+        if StreamProcessing.detect_pipeline(
+            TaskProcessing._logger, task_argument.model
+        ):
             AppLogger.add_to_log(
-                self._logger,
+                TaskProcessing._logger,
                 logging.INFO,
                 "Found the pipeline model. Loading pipeline instances",
             )
-            return self._load_pipeline_instances(task_argument)
+            return TaskProcessing._load_pipeline_instances(task_argument)
 
         else:
             AppLogger.add_to_log(
-                self._logger,
+                TaskProcessing._logger,
                 logging.INFO,
                 "Unable to find pipeline model. Loading non-pipeline instances",
             )
-            return self._load_non_pipeline_instances(task_argument)
+            return TaskProcessing._load_non_pipeline_instances(task_argument)
 
+    @staticmethod
     def _load_non_pipeline_instances(
-        self, task_argument: TaskArgument
+        task_argument: TaskArgument,
     ) -> Tuple[
         bool,
         Tuple[Union[IData, None], Union[ISerializer, None]],
@@ -359,7 +330,7 @@ class TaskProcessing:
                 is_load_data_success,
                 data_serializer_instance,
                 load_data_error_message,
-            ) = StreamProcessing.load_data(self._logger, task_argument.data)
+            ) = StreamProcessing.load_data(TaskProcessing._logger, task_argument.data)
             if not is_load_data_success:
                 is_success = is_load_data_success
                 raise RuntimeError(load_data_error_message)
@@ -380,7 +351,7 @@ class TaskProcessing:
                 model_serializer_instance,
                 load_model_error_message,
             ) = StreamProcessing.load_model(
-                self._logger,
+                TaskProcessing._logger,
                 task_argument.mode,
                 task_argument.model,
                 task_argument.api_schema,
@@ -400,7 +371,7 @@ class TaskProcessing:
                     ground_truth_serializer_instance,
                     load_ground_truth_error_message,
                 ) = StreamProcessing.load_ground_truth(
-                    self._logger, task_argument.ground_truth_dataset
+                    TaskProcessing._logger, task_argument.ground_truth_dataset
                 )
                 if not is_load_ground_truth_success:
                     is_success = is_load_ground_truth_success
@@ -427,7 +398,7 @@ class TaskProcessing:
                 algorithm_serializer_instance,
                 load_algorithm_error_message,
             ) = StreamProcessing.load_algorithm(
-                self._logger,
+                TaskProcessing._logger,
                 task_argument.algorithm_id,
                 task_argument.algorithm_arguments,
                 data_serializer_instance,
@@ -435,7 +406,7 @@ class TaskProcessing:
                 task_argument.ground_truth,
                 model_serializer_instance,
                 task_argument.model_type,
-                self._update_task_progress,
+                TaskProcessing._update_task_progress,
             )
             if not is_load_algorithm_success:
                 is_success = is_load_algorithm_success
@@ -454,8 +425,9 @@ class TaskProcessing:
                 error_message,
             )
 
+    @staticmethod
     def _load_pipeline_instances(
-        self, task_argument: TaskArgument
+        task_argument: TaskArgument,
     ) -> Tuple[
         bool,
         Tuple[Union[IData, None], Union[ISerializer, None]],
@@ -501,7 +473,7 @@ class TaskProcessing:
                 is_load_data_success,
                 data_serializer_instance,
                 load_data_error_message,
-            ) = StreamProcessing.load_data(self._logger, task_argument.data)
+            ) = StreamProcessing.load_data(TaskProcessing._logger, task_argument.data)
             if not is_load_data_success:
                 is_success = is_load_data_success
                 raise RuntimeError(load_data_error_message)
@@ -511,7 +483,9 @@ class TaskProcessing:
                 is_load_model_success,
                 model_serializer_instance,
                 load_model_error_message,
-            ) = StreamProcessing.load_pipeline(self._logger, task_argument.model)
+            ) = StreamProcessing.load_pipeline(
+                TaskProcessing._logger, task_argument.model
+            )
             if not is_load_model_success:
                 is_success = is_load_model_success
                 raise RuntimeError(load_model_error_message)
@@ -540,7 +514,7 @@ class TaskProcessing:
                     ground_truth_serializer_instance,
                     load_ground_truth_error_message,
                 ) = StreamProcessing.load_ground_truth(
-                    self._logger, task_argument.ground_truth_dataset
+                    TaskProcessing._logger, task_argument.ground_truth_dataset
                 )
                 if not is_load_ground_truth_success:
                     is_success = is_load_ground_truth_success
@@ -567,7 +541,7 @@ class TaskProcessing:
                 algorithm_serializer_instance,
                 load_algorithm_error_message,
             ) = StreamProcessing.load_algorithm(
-                self._logger,
+                TaskProcessing._logger,
                 task_argument.algorithm_id,
                 task_argument.algorithm_arguments,
                 data_serializer_instance,
@@ -575,7 +549,7 @@ class TaskProcessing:
                 task_argument.ground_truth,
                 model_serializer_instance,
                 task_argument.model_type,
-                self._update_task_progress,
+                TaskProcessing._update_task_progress,
                 initial_data_serializer_instance[0],
                 initial_model_serializer_instance[0],
             )
@@ -596,7 +570,8 @@ class TaskProcessing:
                 error_message,
             )
 
-    def _update_task_progress(self, completion_progress: int) -> None:
+    @staticmethod
+    def _update_task_progress(completion_progress: int) -> None:
         """
         A helper method to update the new task progress and send task update
 
@@ -604,11 +579,14 @@ class TaskProcessing:
             completion_progress (int): Current progress completion
         """
         # Set the task completion progress
-        self._task_result.set_progress(completion_progress)
-        self._task_update_callback()
+        TaskProcessing._task_result.set_progress(completion_progress)
+        TaskProcessing._result_queue.put(
+            (ProcessStatus.UPDATE, TaskProcessing._task_result)
+        )
 
+    @staticmethod
     def _validate_task_results(
-        self, task_result: Dict, algorithm_output_schema: Dict
+        task_result: Dict, algorithm_output_schema: Dict
     ) -> Tuple[bool, str]:
         """
         A helper method to validate task results according to output schema

--- a/test-engine-core-modules/src/sklearnmodel/sklearnmodel.py
+++ b/test-engine-core-modules/src/sklearnmodel/sklearnmodel.py
@@ -30,6 +30,7 @@ class Plugin(IModel):
         "sklearn.linear_model._base.LinearRegression",
         "sklearn.ensemble._gb.GradientBoostingRegressor",
         "sklearn.ensemble.ExtraTreesRegressor",
+        "sklearn.ensemble._forest.RandomForestRegressor",
     ]
     _name: str = "sklearnmodel"
     _description: str = "sklearnmodel supports detecting sklearn models"

--- a/test-engine-core-modules/src/sklearnmodel/sklearnmodel.py
+++ b/test-engine-core-modules/src/sklearnmodel/sklearnmodel.py
@@ -29,7 +29,7 @@ class Plugin(IModel):
         "sklearn.ensemble._bagging.BaggingClassifier",
         "sklearn.linear_model._base.LinearRegression",
         "sklearn.ensemble._gb.GradientBoostingRegressor",
-        "sklearn.ensemble.ExtraTreesRegressor",
+        "sklearn.ensemble._forest.ExtraTreesRegressor",
         "sklearn.ensemble._forest.RandomForestRegressor",
     ]
     _name: str = "sklearnmodel"

--- a/test-engine-core-modules/src/sklearnmodel/sklearnmodel.py
+++ b/test-engine-core-modules/src/sklearnmodel/sklearnmodel.py
@@ -29,6 +29,7 @@ class Plugin(IModel):
         "sklearn.ensemble._bagging.BaggingClassifier",
         "sklearn.linear_model._base.LinearRegression",
         "sklearn.ensemble._gb.GradientBoostingRegressor",
+        "sklearn.ensemble.ExtraTreesRegressor",
     ]
     _name: str = "sklearnmodel"
     _description: str = "sklearnmodel supports detecting sklearn models"


### PR DESCRIPTION
…ead of processing algorithm instance at a later time. Added a new enum to allow control through the multiprocess queue.

## Description

Fixed critical bug where algorithm instance hangs when using certain model.

## Motivation and Context

Algorithm instance hangs when using certain model while performing tests.

## Type of Change
- fix: A bug fix

## How to Test

Testing is still ongoing

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [x]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [ ]  I have performed a self-review of my own code.
- [ ]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>
