### PR TITLE
Fix/issue 77 report title not substituted

### DIFF
--- a/ai-verify-portal/pages/project/[id].tsx
+++ b/ai-verify-portal/pages/project/[id].tsx
@@ -17,7 +17,6 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
   const id = params.id as string;
   const data = await getProject(id);
   const pluginManager = await getPlugins();
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { __typename, ...modelAndDatasets } =
     data.modelAndDatasets as ModelAndDatasets & {
       __typename: string | undefined;
@@ -25,21 +24,18 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
   if (modelAndDatasets) {
     const { groundTruthDataset, model, testDataset } = modelAndDatasets;
     if (groundTruthDataset) {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { __typename, ...rest } = groundTruthDataset as Dataset & {
         __typename: string;
       };
       modelAndDatasets.groundTruthDataset = rest;
     }
     if (model) {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { __typename, ...rest } = model as ModelFile & {
         __typename: string;
       };
       modelAndDatasets.model = rest;
     }
     if (testDataset) {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { __typename, ...rest } = testDataset as Dataset & {
         __typename: string;
       };

--- a/ai-verify-portal/server/lib/projectServiceBackend.ts
+++ b/ai-verify-portal/server/lib/projectServiceBackend.ts
@@ -181,7 +181,6 @@ export async function listProjects(): Promise<Project[]> {
 }
 
 export async function getProject(id: string): Promise<Project> {
-  console.log('getProject');
   const client = graphqlClient(true);
   try {
     const { data } = await client.query({

--- a/ai-verify-portal/src/lib/projectService.ts
+++ b/ai-verify-portal/src/lib/projectService.ts
@@ -67,6 +67,8 @@ export const CREATE_PROJECT_FROM_TEMPLATE = gql`
       projectInfo {
         name
         description
+        reportTitle
+        company
       }
       globalVars {
         key

--- a/ai-verify-portal/src/modules/project/index.tsx
+++ b/ai-verify-portal/src/modules/project/index.tsx
@@ -10,7 +10,7 @@ import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 
 import Project, { ProjectReportStatus } from 'src/types/project.interface';
-import { useProjectStore } from './projectContext';
+import { ARUActionTypes, useProjectStore } from './projectContext';
 
 import { Algorithm } from 'src/types/plugin.interface';
 import ProjectInformationComponent from './projectInformation';
@@ -94,6 +94,35 @@ export default function ProjectModule({ data, pluginManager }: Props) {
         if (selectedProjectTemplateId == BlankTemplateId) {
           if (projectStore.isNew) {
             await projectStore.createProject();
+            for (const propertyName in projectStore.projectInfo) {
+              if (propertyName === '__typename') continue;
+              const idx = projectStore.globalVars.findIndex(
+                (gvar) => gvar.key === propertyName
+              );
+              const gVarValue =
+                projectStore.projectInfo[
+                  propertyName as
+                    | 'name'
+                    | 'company'
+                    | 'reportTitle'
+                    | 'description'
+                ];
+              if (gVarValue == null) continue;
+              if (idx < 0 || gVarValue !== projectStore.globalVars[idx].value) {
+                if (idx < 0) {
+                  projectStore.dispatchGlobalVars({
+                    type: ARUActionTypes.ADD,
+                    payload: { key: propertyName, value: gVarValue },
+                  });
+                } else {
+                  projectStore.dispatchGlobalVars({
+                    type: ARUActionTypes.UPDATE,
+                    index: idx,
+                    payload: { key: propertyName, value: gVarValue },
+                  });
+                }
+              }
+            }
             setStep(ProjectStep.DesignReport);
             return;
           }

--- a/ai-verify-portal/src/modules/project/index.tsx
+++ b/ai-verify-portal/src/modules/project/index.tsx
@@ -94,44 +94,17 @@ export default function ProjectModule({ data, pluginManager }: Props) {
         if (selectedProjectTemplateId == BlankTemplateId) {
           if (projectStore.isNew) {
             await projectStore.createProject();
-            for (const propertyName in projectStore.projectInfo) {
-              if (propertyName === '__typename') continue;
-              const idx = projectStore.globalVars.findIndex(
-                (gvar) => gvar.key === propertyName
-              );
-              const gVarValue =
-                projectStore.projectInfo[
-                  propertyName as
-                    | 'name'
-                    | 'company'
-                    | 'reportTitle'
-                    | 'description'
-                ];
-              if (gVarValue == null) continue;
-              if (idx < 0 || gVarValue !== projectStore.globalVars[idx].value) {
-                if (idx < 0) {
-                  projectStore.dispatchGlobalVars({
-                    type: ARUActionTypes.ADD,
-                    payload: { key: propertyName, value: gVarValue },
-                  });
-                } else {
-                  projectStore.dispatchGlobalVars({
-                    type: ARUActionTypes.UPDATE,
-                    index: idx,
-                    payload: { key: propertyName, value: gVarValue },
-                  });
-                }
-              }
-            }
             setStep(ProjectStep.DesignReport);
             return;
           }
         }
         if (projectStore.isNew) {
           const id = await projectStore.createProjectFromTemplate(
-            selectedProjectTemplateId
+            selectedProjectTemplateId,
+            () => {
+              if (id) router.push(`/project/${id}`);
+            }
           );
-          if (id) router.push(`/project/${id}`);
         }
         break;
       case ProjectStep.CaptureTestInput:

--- a/ai-verify-portal/src/modules/project/projectInformation.tsx
+++ b/ai-verify-portal/src/modules/project/projectInformation.tsx
@@ -1,5 +1,6 @@
 import { TextInput } from 'src/components/textInput';
 import {
+  ARUActionTypes,
   ProjectTemplateStore,
   UpdateActionTypes,
 } from '../projectTemplate/projectTemplateContext';
@@ -65,6 +66,31 @@ export default function ProjectInformationComponent(props: ProjectInfoProps) {
       type: UpdateActionTypes.UPDATE,
       payload: projectGeneralInfo,
     });
+    for (const propertyName in projectGeneralInfo) {
+      if (propertyName === '__typename') continue;
+      const idx = projectStore.globalVars.findIndex(
+        (gvar) => gvar.key === propertyName
+      );
+      const gVarValue =
+        projectGeneralInfo[
+          propertyName as 'name' | 'company' | 'reportTitle' | 'description'
+        ];
+      if (gVarValue == null) continue;
+      if (idx < 0 || gVarValue !== projectStore.globalVars[idx].value) {
+        if (idx < 0) {
+          projectStore.dispatchGlobalVars({
+            type: ARUActionTypes.ADD,
+            payload: { key: propertyName, value: gVarValue },
+          });
+        } else {
+          projectStore.dispatchGlobalVars({
+            type: ARUActionTypes.UPDATE,
+            index: idx,
+            payload: { key: propertyName, value: gVarValue },
+          });
+        }
+      }
+    }
   }, [projectGeneralInfo]);
 
   useEffect(() => {

--- a/ai-verify-portal/src/modules/projectTemplate/canvas.tsx
+++ b/ai-verify-portal/src/modules/projectTemplate/canvas.tsx
@@ -380,14 +380,7 @@ export default function CanvasComponent(props: CanvasProps) {
     return projectStore.pages[currentPageNo.current];
   };
 
-  const combinedGlobalVars = useMemo(() => {
-    return [
-      ...Object.entries(projectStore.projectInfo)
-        .filter((item) => item[0] !== '__typename')
-        .map((item) => ({ key: item[0], value: item[1] })),
-      ...projectStore.globalVars,
-    ] as GlobalVariable[];
-  }, [projectStore.globalVars, projectStore.projectInfo]);
+  const combinedGlobalVars = projectStore.globalVars;
 
   function handleAddPageClick(pageIndex = -1) {
     setinitialLayout([]);


### PR DESCRIPTION
## Description

This PR fixes [issue-77](https://github.com/IMDA-BTG/aiverify/issues/77) where report title global variable is not substituted with its value when used on report.

## Motivation and Context

The root cause of this is global vars created in memory from project info at project creation is not saved in DB.
Code changes in the fix:
- create the global variables from project info at project creation for both `blank template` and `use template` projects.
- challenge
The reducers have no `await promise mechanism` so execution cannot await DB saves. Also, all save to DB methods in the custom dispatch methods are debounced for 5 seconds.
- solution
Provide a `callback fn argument` to the dispatch action so that this fn will be called only after variables are saved to DB. This solved a problem where after creating a project from template, the toolkit routes user by full page refresh, to the canvas screen without waiting for global vars to be saved. However, this caused a delay of 5 seconds before the routing is invoked and user has to wait for 5 seconds on the template screen after clicking next button. Debounce flush() method just doesn't work here too. So the only solution to fix this delay is to create a non debounced version of globalVars save method and use it on project creation.

Some cleanups of commented out codes were also done


## Type of Change

<!-- Select the appropriate type of change: -->
<!-- - feat: A new feature -->
- fix: A bug fix
<!-- - chore: Routine tasks, maintenance, or tooling changes -->
<!-- - docs: Documentation updates -->
<!-- - style: Code style changes (e.g., formatting, indentation) -->
<!-- - refactor: Code refactoring without changes in functionality -->
<!-- - test: Adding or modifying tests -->
<!-- - perf: Performance improvements -->
<!-- - ci: Changes to the CI/CD configuration or scripts -->
<!-- - other: Other changes that don't fit into the above categories -->

## How to Test

### use blank template
1. Create a project using `blank` template
2. Add a few heading widgets to canvas.
3. Populate the heading texts using global variables (name, reportTitle, company, description)
4. Generate report and check that the headings are printed accordingly


### use existing template
1. Create a project using `existing` template
2. Add a few heading widgets to canvas.
3. Populate the heading texts using global variables (name, reportTitle, company, description)
4. Generate report and check that the headings are printed accordingly

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x ]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [ ]  I have followed the project's coding conventions and style guidelines.
- [ x]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [x ]  I have performed a self-review of my own code.
- [x ]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>
