### PR TITLE
fix typos for image preparation notebook

### DIFF
--- a/docs/getting-started/prepare-image.ipynb
+++ b/docs/getting-started/prepare-image.ipynb
@@ -836,7 +836,7 @@
     "\n",
     "In summary, for this example, users may upload the following for testing:\n",
     "- Data: 'data/raw_fashion_image_10' \n",
-    "- Ground Truth Dataset/ Annotated Ground Truth Path: 'data/pickle_pandas_fashion_mnist_annotated_labels_10.sav' ; Select Ground Truth : `default` ; Name of column containing image file names : `file_name`\n",
+    "- Ground Truth Dataset/ Annotated Ground Truth Path: 'data/pickle_pandas_fashion_mnist_annotated_labels_10.sav' ; Select Ground Truth : `labels` ; Name of column containing image file names : `file_name`\n",
     "- Model: 'pipeline/multiclass_classification_image_mnist_fashion' ; Note that the model should be uploaded as a folder as it is a pipeline\n",
     "\n",
     "\n",


### PR DESCRIPTION
## Description

Correction of typo in documentation that guides users to prepare image datasets

## Motivation and Context

The typo lies in the selection of the ground truth label, which will lead to errors in performing test run with the sample datasets.

## Type of Change

 - docs: Documentation updates 
 

## How to Test

Deploy using Github pages and check that the typo has been corrected in Preparation of Image Files > 
How to Prepare Image Datasets and Models, and that the .zip file for preparation of image dataset can be downloaded with the link provided in the documentation.

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [x]  I have added or updated the necessary documentation (README, API docs, etc.).
- [x]  I have added appropriate unit tests or functional tests for the changes made.
- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch onto the latest commit of the main branch.
- [x]  I have squashed or reorganized my commits into logical units.
- [x]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

![image](https://github.com/IMDA-BTG/aiverify/assets/130044746/1a3ebc3c-7853-4478-a929-e93350b84863)

## Additional Notes

N.A.

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>
