### PR TITLE
Fix/scr 009

### DIFF
--- a/.github/workflows/contribution.yml
+++ b/.github/workflows/contribution.yml
@@ -117,11 +117,7 @@ jobs:
           cd ../ai-verify-portal
           npm install
           npm link ../ai-verify-shared-library
-          echo "NEXT_PUBLIC_SERVER_URL=http://127.0.0.1:3000
-          NEXT_PUBLIC_WEBSOCKET_URL=ws://127.0.0.1:4000/graphql
-          SERVER_URL=http://127.0.0.1:3000
-          WEBSOCKET_URL=ws://127.0.0.1:4000/graphql
-          APIGW_URL=http://127.0.0.1:4000
+          echo "APIGW_URL=http://127.0.0.1:4000
           MONGODB_URI=mongodb://aiverify:aiverify@127.0.0.1:27017/aiverify
           REDIS_URI=redis://127.0.0.1:6379
           TEST_ENGINE_URL=http://127.0.0.1:8080" > .env.local

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -119,11 +119,7 @@ jobs:
           cd ../ai-verify-portal
           npm install
           npm link ../ai-verify-shared-library
-          echo "NEXT_PUBLIC_SERVER_URL=http://127.0.0.1:3000
-          NEXT_PUBLIC_WEBSOCKET_URL=ws://127.0.0.1:4000/graphql
-          SERVER_URL=http://127.0.0.1:3000
-          WEBSOCKET_URL=ws://127.0.0.1:4000/graphql
-          APIGW_URL=http://127.0.0.1:4000
+          echo "APIGW_URL=http://127.0.0.1:4000
           MONGODB_URI=mongodb://aiverify:aiverify@127.0.0.1:27017/aiverify
           REDIS_URI=redis://127.0.0.1:6379
           TEST_ENGINE_URL=http://127.0.0.1:8080" > .env.local

--- a/ai-verify-portal/.env.development
+++ b/ai-verify-portal/.env.development
@@ -1,7 +1,3 @@
-NEXT_PUBLIC_SERVER_URL=http://localhost:3000
-NEXT_PUBLIC_WEBSOCKET_URL=ws://localhost:4000/graphql
-SERVER_URL=http://localhost:3000
-WEBSOCKET_URL=ws://localhost:4000/graphql
 APIGW_URL=http://localhost:4000
 MONGODB_URI=mongodb://aiverify:aiverify@localhost:27017/aiverify
 REDIS_URI=redis://localhost:6379

--- a/ai-verify-portal/src/lib/graphqlClient.ts
+++ b/ai-verify-portal/src/lib/graphqlClient.ts
@@ -3,32 +3,32 @@ import { getMainDefinition } from '@apollo/client/utilities';
 import { GraphQLWsLink } from '@apollo/client/link/subscriptions';
 import { createClient } from 'graphql-ws';
 
-// Add NEXT_PUBLIC_ prefix to the following env variables to expose them to browser side.
-const URL =
-  process.env.SERVER_URL ||
-  process.env.NEXT_PUBLIC_SERVER_URL ||
-  'http://localhost:3000';
-const WSURL =
-  process.env.WEBSOCKET_URL ||
-  process.env.NEXT_PUBLIC_WEBSOCKET_URL ||
-  'ws://localhost:4000/graphql';
-
 /**
  * Create a new apollo client
  * @param ssrMode set true to enable ssrMode for server-side rendering
  * @returns apollo client object
  */
 export default function graphqlClient(ssrMode = false) {
-  const httpLink = new HttpLink({ uri: `${URL}/api/graphql` });
-  const wsLink =
-    typeof window !== 'undefined'
-      ? new GraphQLWsLink(
-          createClient({
-            url: WSURL,
-          })
-        )
-      : null;
+  const isClient = typeof window !== 'undefined' && !ssrMode;
+  // if client use relative path, if server mode connect direct to api-gw
+  const uri = isClient ? '/api/graphql' : `${process.env.APIGW_URL}/graphql`;
+  const httpLink = new HttpLink({ uri: uri });
 
+  let wsLink = null;
+  if (isClient) {
+    // only connect to graphql subscription for client
+    // if env WEBSOCKET_URL not defined, assume api-gw always hosted on the same host
+    const wsprot = window.location.protocol === 'http:'?'ws':'wss';
+    const wsuri = process.env.WEBSOCKET_URL || `${wsprot}://${window.location.hostname || 'localhost'}:4000/graphql`;
+    // console.log("wsuri:", wsuri);
+    wsLink = new GraphQLWsLink(
+      createClient({
+        url: wsuri,
+      })
+    );
+  }
+
+  // console.log("uri:", uri);
   const link =
     typeof window !== 'undefined' && wsLink != null
       ? split(

--- a/ai-verify-portal/src/lib/graphqlClient.ts
+++ b/ai-verify-portal/src/lib/graphqlClient.ts
@@ -19,7 +19,7 @@ export default function graphqlClient(ssrMode = false) {
     // only connect to graphql subscription for client
     // if env WEBSOCKET_URL not defined, assume api-gw always hosted on the same host
     const wsprot = window.location.protocol === 'http:'?'ws':'wss';
-    const wsuri = process.env.WEBSOCKET_URL || `${wsprot}://${window.location.hostname || 'localhost'}:4000/graphql`;
+    const wsuri = process.env.NEXT_PUBLIC_WEBSOCKET_URL || `${wsprot}://${window.location.hostname}:${window.location.port}/api/graphql`;
     // console.log("wsuri:", wsuri);
     wsLink = new GraphQLWsLink(
       createClient({

--- a/setup-aiverify/aiverify-user/Dockerfile
+++ b/setup-aiverify/aiverify-user/Dockerfile
@@ -94,11 +94,7 @@ WORKDIR /app/aiverify/ai-verify-portal
 ARG PORTAL_URL=http://localhost
 ARG WS_URL=ws://localhost
 RUN echo "PORTAL_URL=$PORTAL_URL WS_URL=$WS_URL"
-RUN echo "NEXT_PUBLIC_SERVER_URL=${PORTAL_URL}:3000\n\
-NEXT_PUBLIC_WEBSOCKET_URL=${WS_URL}:4000/graphql\n\
-SERVER_URL=http://localhost:3000\n\
-WEBSOCKET_URL=ws://localhost:4000/graphql\n\
-APIGW_URL=http://localhost:4000\n\
+RUN echo "APIGW_URL=http://localhost:4000\n\
 MONGODB_URI=mongodb://aiverify:aiverify@db:27017/aiverify\n\
 REDIS_URI=redis://redis:6379\n\
 TEST_ENGINE_URL=http://test-engine:8080" | tee .env.local


### PR DESCRIPTION
## Description

Update the portal graphql client so that all browser requests uses the portal rewrites for graphql client requests and subscriptions. Graphql URL are automatically formatted using the window.location hostname and port, so that WS connections connect to the right hostname instead of default localhost. 

This fix should also resolve issue: https://github.com/IMDA-BTG/aiverify/issues/169

The follow variables are remove from portal .env.development:
NEXT_PUBLIC_SERVER_URL, NEXT_PUBLIC_WEBSOCKET_URL, SERVER_URL, WEBSOCKET_URL
Only NEXT_PUBLIC_WEBSOCKET_URL is still in use but it should be set only if the websocket URL need to be hardcoded.

## Motivation and Context

[Explain the motivation or the context behind this pull request. Why is it necessary?]

## Type of Change

fix:
The portal graphql URL should now be set correctly without having to set the SEVER_URL and WEBSOCKET_URL env.

## How to Test

Deploy and run the ai-verify-apigw and ai-verify-portal on one server. Access the portal from another PC or laptop and observe the http requests to make sure there's no connection errors.

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [ x]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [x ]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>
