### PR TITLE
improve environment variable inheritance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 venv
+.venv
 coverage
 /uploads/
 /package-lock.json

--- a/ai-verify-apigw/app.mjs
+++ b/ai-verify-apigw/app.mjs
@@ -11,7 +11,7 @@ import uploadRouter from './routes/upload.mjs';
 import { createApolloServer } from './graphql/server.mjs';
 
 const allowedOrigins = process.env.ALLOWED_ORIGINS !== undefined ?
-  process.env.ALLOWED_ORIGINS.split(',') : ['http://localhost:3000','http://localhost:4000'];
+  process.env.ALLOWED_ORIGINS.split(',') : ['http://localhost:3000','http://localhost:4000','http://127.0.0.1:3000','http://127.0.0.1:4000'];
 const app = express();
 
 // enable trust proxy, see https://expressjs.com/en/guide/behind-proxies.html

--- a/test-engine-app/test_engine_app/config/environment_variables.py
+++ b/test-engine-app/test_engine_app/config/environment_variables.py
@@ -1,7 +1,8 @@
+import os
 from pathlib import Path
 from typing import Tuple
 
-from dotenv import dotenv_values
+from dotenv import load_dotenv
 from test_engine_core.utils.validate_checks import is_empty_string
 
 
@@ -10,7 +11,6 @@ class EnvironmentVariables:
     EnvironmentVariables class focuses on getting external environment variables that may affect how the program runs.
     """
 
-    _default_env_file: str = ".env"
     _core_modules_folder: str = "../test-engine-core-modules"
     _validation_schemas_folder: str = "./test_engine_app/validation_schemas/"
     _redis_consumer_group: str = "MyGroup"
@@ -20,46 +20,43 @@ class EnvironmentVariables:
 
     def __init__(self):
         try:
-            # Check if the '.env' file exists
-            if Path.exists(Path(self._default_env_file)):
-                # Read the environment variable file and load the variables
-                env_config = dotenv_values(self._default_env_file)
+            load_dotenv()
 
-                # Save the values obtained from the file, else we use default values
-                core_modules_folder = env_config.get(
-                    "CORE_MODULES_FOLDER",
-                    str(Path().resolve().parent / "test-engine-core-modules"),
-                )
-                validation_schemas_folder = env_config.get(
-                    "VALIDATION_SCHEMAS_FOLDER",
-                    str(Path().resolve() / "test_engine_app/validation_schemas"),
-                )
-                consumer_group = env_config.get("REDIS_CONSUMER_GROUP", "MyGroup")
-                hostname = env_config.get("REDIS_SERVER_HOSTNAME", "localhost")
-                server_port = int(env_config.get("REDIS_SERVER_PORT", 6379))
-                api_server_port = int(env_config.get("API_SERVER_PORT", 8080))
+            # Save the values obtained from the file, else we use default values
+            core_modules_folder = os.getenv(
+                "CORE_MODULES_FOLDER",
+                str(Path().resolve().parent / "test-engine-core-modules"),
+            )
+            validation_schemas_folder = os.getenv(
+                "VALIDATION_SCHEMAS_FOLDER",
+                str(Path().resolve() / "test_engine_app/validation_schemas"),
+            )
+            consumer_group = os.getenv("REDIS_CONSUMER_GROUP", "MyGroup")
+            hostname = os.getenv("REDIS_SERVER_HOSTNAME", "localhost")
+            server_port = int(os.getenv("REDIS_SERVER_PORT", 6379))
+            api_server_port = int(os.getenv("API_SERVER_PORT", 8080))
 
-                error_count, _ = EnvironmentVariables._validate_data(
-                    core_modules_folder,
-                    validation_schemas_folder,
-                    consumer_group,
-                    hostname,
-                    server_port,
-                    api_server_port,
-                )
+            error_count, _ = EnvironmentVariables._validate_data(
+                core_modules_folder,
+                validation_schemas_folder,
+                consumer_group,
+                hostname,
+                server_port,
+                api_server_port,
+            )
 
-                if error_count == 0:
-                    EnvironmentVariables._core_modules_folder = core_modules_folder
-                    EnvironmentVariables._validation_schemas_folder = (
-                        validation_schemas_folder
-                    )
-                    EnvironmentVariables._redis_consumer_group = consumer_group
-                    EnvironmentVariables._redis_server_hostname = hostname
-                    EnvironmentVariables._redis_server_port = server_port
-                    EnvironmentVariables._api_server_port = api_server_port
-                else:
-                    # Validation failed. Use defaults.
-                    pass
+            if error_count == 0:
+                EnvironmentVariables._core_modules_folder = core_modules_folder
+                EnvironmentVariables._validation_schemas_folder = (
+                    validation_schemas_folder
+                )
+                EnvironmentVariables._redis_consumer_group = consumer_group
+                EnvironmentVariables._redis_server_hostname = hostname
+                EnvironmentVariables._redis_server_port = server_port
+                EnvironmentVariables._api_server_port = api_server_port
+            else:
+                # Validation failed. Use defaults.
+                pass
 
         except ValueError:
             # ValueError exception. Use defaults.

--- a/test-engine-app/tests/conftest.py
+++ b/test-engine-app/tests/conftest.py
@@ -1,0 +1,12 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def test_setup_and_teardown():
+    old_environ = dict(os.environ)
+    yield
+
+    os.environ.clear()
+    os.environ.update(old_environ)

--- a/test-engine-app/tests/test_environment_variables.py
+++ b/test-engine-app/tests/test_environment_variables.py
@@ -3,7 +3,6 @@ import shutil
 from pathlib import Path
 
 import pytest
-
 from test_engine_app.config.environment_variables import EnvironmentVariables
 
 
@@ -790,14 +789,14 @@ class TestCollectionEnvironmentVariables:
             (
                 {
                     "core_modules_folder": str(Path().resolve().parent / "test-engine-core-modules"),
-                    "validation_folder": str(Path().resolve() / "validation_schemas"),
+                    "validation_folder": str(Path().resolve() / "test_engine_app/validation_schemas"),
                     "consumer_group": "MyGroup",
                     "hostname": "localhost",
                     "server_port": 6379,
                     "api_server_port": 8080
                 },
                 f'\nEnvironment Variables:\nCORE_MODULES_FOLDER: {str(Path().resolve().parent / "test-engine-core-modules")}\n'
-                f'VALIDATION_SCHEMAS_FOLDER: {str(Path().resolve() / "validation_schemas")}\n'
+                f'VALIDATION_SCHEMAS_FOLDER: {str(Path().resolve() / "test_engine_app/validation_schemas")}\n'
                 f'REDIS_CONSUMER_GROUP: MyGroup\n'
                 f'REDIS_SERVER_HOSTNAME: localhost\n'
                 f'REDIS_SERVER_PORT: 6379\n'


### PR DESCRIPTION
## Description

Load .env by default for test_engine_app but allow overwriting the values with environment variables

## Motivation and Context

To allow flexibility in how to run the applications some changes are preferred in how the variables are loaded. 

Also added 127.0.0.1 to ALLOW_ORIGINS since some tools prefer using this. (VSCode) 

## Type of Change

<!-- - fix: A bug fix -->

## How to Test

run from test-engine-app: pytest tests/test_environment_variables.py

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [X]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [X]  I have added appropriate unit tests or functional tests for the changes made.
- [X]  I have followed the project's coding conventions and style guidelines.
- [X]  I have rebased my branch onto the latest commit of the main branch.
- [X]  I have squashed or reorganized my commits into logical units.
- [x]  I have added any necessary dependencies or packages to the project's build configuration.
- [X]  I have performed a self-review of my own code.
- [X]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>
