### PR TITLE
Visitor tracker for cccs plugins

### DIFF
--- a/third-party-plugins/cccs_plugins/README.md
+++ b/third-party-plugins/cccs_plugins/README.md
@@ -1,6 +1,5 @@
 [![Visitors](https://api.visitorbadge.io/api/combined?path=https%3A%2F%2Fgithub.com%2Faiverify-foundation%2Faiverify%2Ftree%2Fmain%2Fthird-party-plugins%2Fcccs_plugins&countColor=%23263759)](https://visitorbadge.io/status?path=https%3A%2F%2Fgithub.com%2Faiverify-foundation%2Faiverify%2Ftree%2Fmain%2Fthird-party-plugins%2Fcccs_plugins)
 
-
 # AIM Toolkit Quick Start Guide
 ![](images/AIM_quick_start_guide.png)
 


### PR DESCRIPTION
## Description

Added tracker in README to track number of visitors downloading cccs plugins

## Motivation and Context

[Explain the motivation or the context behind this pull request. Why is it necessary?]

## Type of Change

<!-- - feat: A new feature -->

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>
